### PR TITLE
Switch test configs to app env aware export

### DIFF
--- a/lib/boundary/hubot/adapters/__tests__/slack.test.ts
+++ b/lib/boundary/hubot/adapters/__tests__/slack.test.ts
@@ -2,7 +2,7 @@ import type { SocketModeClient } from "@slack/socket-mode";
 import type { WebClient } from "@slack/web-api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { type DeepMockProxy, anyArray, mockDeep } from "vitest-mock-extended";
-import { testConfig } from "../../../../../config/test.js";
+import { config } from "../../../../../config/index.js";
 import { createIncident, createLogEntry } from "../../../../../test/index.js";
 import type { BreakingBot } from "../../../../types/index.js";
 import { Slack } from "../slack.js";
@@ -154,7 +154,7 @@ describe("slack.ts", () => {
 		test("success", async () => {
 			const incident = createIncident();
 
-			await slack.introNewIncident(incident, testConfig, "BREAKING-123");
+			await slack.introNewIncident(incident, config, "BREAKING-123");
 
 			expect(webClient.conversations.setTopic).toHaveBeenCalledWith({
 				channel: incident.chatRoomUid,
@@ -178,7 +178,7 @@ describe("slack.ts", () => {
 		test("no chat room errors out", () => {
 			const incident = createIncident({ chatRoomUid: null });
 			expectProcessExit(async () =>
-				slack.introNewIncident(incident, testConfig, "BREAKING-123"),
+				slack.introNewIncident(incident, config, "BREAKING-123"),
 			);
 		});
 	});
@@ -924,11 +924,11 @@ describe("slack.ts", () => {
 	});
 
 	test("sendPriorities", async () => {
-		await slack.sendPriorities("C8732838", testConfig.priorities, "m405");
+		await slack.sendPriorities("C8732838", config.priorities, "m405");
 
 		expect(webClient.chat.postMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
-				blocks: priorityBlocks(testConfig.priorities),
+				blocks: priorityBlocks(config.priorities),
 				channel: "C8732838",
 				text: "Priorities: P1, P2, P3, P4, P5",
 				// biome-ignore lint/style/useNamingConvention: Slack defined
@@ -1023,13 +1023,13 @@ describe("slack.ts", () => {
 	});
 
 	test("sendHelpMessage", async () => {
-		await slack.sendHelpMessage("C8732838", testConfig, "m405");
+		await slack.sendHelpMessage("C8732838", config, "m405");
 
 		expect(webClient.chat.postMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
-				blocks: helpBlocks(testConfig),
+				blocks: helpBlocks(config),
 				channel: "C8732838",
-				text: `Help: ${testConfig.runbookRootUrl}`,
+				text: `Help: ${config.runbookRootUrl}`,
 				// biome-ignore lint/style/useNamingConvention: Slack defined
 				thread_ts: "m405",
 				// biome-ignore lint/style/useNamingConvention: Slack defined
@@ -1040,7 +1040,7 @@ describe("slack.ts", () => {
 
 	describe("sendMaintenanceAlert", () => {
 		test("send without specific message", async () => {
-			await slack.sendMaintenanceAlert(testConfig.commPlatform, "C784574");
+			await slack.sendMaintenanceAlert(config.commPlatform, "C784574");
 
 			expect(webClient.chat.postMessage).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -1055,7 +1055,7 @@ describe("slack.ts", () => {
 
 		test("send with specific message", async () => {
 			await slack.sendMaintenanceAlert(
-				testConfig.commPlatform,
+				config.commPlatform,
 				"C784574",
 				"oof, ouch, bammy happened",
 			);
@@ -1072,7 +1072,7 @@ describe("slack.ts", () => {
 		});
 
 		test("send with mention without specific message", async () => {
-			const cfg = { ...testConfig.commPlatform, botEngSubteamId: "S278874" };
+			const cfg = { ...config.commPlatform, botEngSubteamId: "S278874" };
 
 			await slack.sendMaintenanceAlert(cfg, "C784574");
 
@@ -1092,7 +1092,7 @@ describe("slack.ts", () => {
 		});
 
 		test("send with mention with specific message", async () => {
-			const cfg = { ...testConfig.commPlatform, botEngSubteamId: "S278874" };
+			const cfg = { ...config.commPlatform, botEngSubteamId: "S278874" };
 
 			await slack.sendMaintenanceAlert(
 				cfg,
@@ -1116,7 +1116,7 @@ describe("slack.ts", () => {
 		});
 
 		test("send without channel does noting", async () => {
-			await slack.sendMaintenanceAlert(testConfig.commPlatform);
+			await slack.sendMaintenanceAlert(config.commPlatform);
 			expect(webClient.chat.postMessage).not.toHaveBeenCalled();
 		});
 	});

--- a/lib/boundary/hubot/adapters/slack/__tests__/blocks.test.ts
+++ b/lib/boundary/hubot/adapters/slack/__tests__/blocks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { anyString } from "vitest-mock-extended";
-import { testConfig } from "../../../../../../config/test.js";
+import { config } from "../../../../../../config/index.js";
 import { createLogEntry } from "../../../../../../test/index.js";
 import {
 	aiBlocks,
@@ -208,7 +208,7 @@ describe("slack/blocks.ts", () => {
 	});
 
 	test("priorityBlocks", () => {
-		expect(priorityBlocks(testConfig.priorities)).toStrictEqual([
+		expect(priorityBlocks(config.priorities)).toStrictEqual([
 			{
 				text: {
 					emoji: true,

--- a/lib/boundary/hubot/adapters/slack/__tests__/strings.test.ts
+++ b/lib/boundary/hubot/adapters/slack/__tests__/strings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { mockDeep } from "vitest-mock-extended";
-import { testConfig } from "../../../../../../config/test.js";
+import { config } from "../../../../../../config/index.js";
 import {
 	createBlocker,
 	createIncident,
@@ -52,7 +52,7 @@ describe("slack/string.ts", () => {
 		test("active incident without roles and without blockage", () => {
 			const inactiveIncident = createIncident({
 				title: "Test Incident Low Priority",
-				priority: testConfig.priorities.defaultLow,
+				priority: config.priorities.defaultLow,
 			});
 
 			const topic = fmtIncidentTopic(inactiveIncident);

--- a/lib/boundary/hubot/handlers/__tests__/affected.test.ts
+++ b/lib/boundary/hubot/handlers/__tests__/affected.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { type DeepMockProxy, mockDeep } from "vitest-mock-extended";
-import { testConfig } from "../../../../../config/test.js";
+import { config } from "../../../../../config/index.js";
 import {
 	TEST_ROOM,
 	createIncident,
@@ -17,7 +17,7 @@ describe("affected.ts", () => {
 	beforeEach(() => {
 		robot = mockDeep<BreakingBot>();
 		// @ts-expect-error
-		robot.config = { ...testConfig };
+		robot.config = { ...config };
 		// @ts-expect-error
 		robot.incidents[TEST_ROOM] = newIncidentMachine(createIncident());
 	});

--- a/lib/boundary/hubot/handlers/__tests__/blocker.test.ts
+++ b/lib/boundary/hubot/handlers/__tests__/blocker.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { type DeepMockProxy, mockDeep } from "vitest-mock-extended";
-import { testConfig } from "../../../../../config/test.js";
+import { config } from "../../../../../config/index.js";
 import {
 	TEST_ROOM,
 	createBlocker,
@@ -18,7 +18,7 @@ describe("blocker.ts", () => {
 	beforeEach(() => {
 		robot = mockDeep<BreakingBot>();
 		// @ts-expect-error
-		robot.config = { ...testConfig };
+		robot.config = { ...config };
 		// @ts-expect-error
 		robot.incidents[TEST_ROOM] = newIncidentMachine(createIncident());
 	});

--- a/lib/boundary/hubot/handlers/__tests__/component.test.ts
+++ b/lib/boundary/hubot/handlers/__tests__/component.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { type DeepMockProxy, mockDeep } from "vitest-mock-extended";
-import { testConfig } from "../../../../../config/test.js";
+import { config } from "../../../../../config/index.js";
 import {
 	TEST_ROOM,
 	createIncident,
@@ -17,7 +17,7 @@ describe("component.ts", () => {
 	beforeEach(() => {
 		robot = mockDeep<BreakingBot>();
 		// @ts-expect-error
-		robot.config = { ...testConfig };
+		robot.config = { ...config };
 		// @ts-expect-error
 		robot.incidents[TEST_ROOM] = newIncidentMachine(createIncident());
 	});

--- a/lib/boundary/hubot/handlers/__tests__/incident.test.ts
+++ b/lib/boundary/hubot/handlers/__tests__/incident.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { type DeepMockProxy, mockDeep } from "vitest-mock-extended";
-import { testConfig } from "../../../../../config/test.js";
+import { config } from "../../../../../config/index.js";
 import {
 	TEST_ROOM,
 	TEST_TRACKER,
@@ -57,7 +57,7 @@ describe("incident.ts", () => {
 	beforeEach(() => {
 		robot = mockDeep<BreakingBot>();
 		// @ts-expect-error
-		robot.config = { ...testConfig };
+		robot.config = { ...config };
 		// @ts-expect-error
 		robot.incidents[TEST_ROOM] = newIncidentMachine({ ...newIncident });
 		// @ts-expect-error
@@ -95,7 +95,7 @@ describe("incident.ts", () => {
 		test("success low priority", async () => {
 			robot.db.transaction.mockResolvedValue({
 				...newIncidentDbRecord,
-				priority: testConfig.priorities.defaultLow,
+				priority: config.priorities.defaultLow,
 			});
 
 			mockFluentDbUpdateOnce(robot, null);
@@ -105,7 +105,7 @@ describe("incident.ts", () => {
 				robot,
 				"test123!",
 				"juan",
-				testConfig.priorities.defaultLow,
+				config.priorities.defaultLow,
 			);
 
 			expect(robot.db.transaction).toHaveBeenCalledTimes(1);

--- a/lib/boundary/hubot/handlers/__tests__/log.test.ts
+++ b/lib/boundary/hubot/handlers/__tests__/log.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { type DeepMockProxy, mockDeep } from "vitest-mock-extended";
-import { testConfig } from "../../../../../config/test.js";
+import { config } from "../../../../../config/index.js";
 import {
 	TEST_ROOM,
 	createIncident,
@@ -22,7 +22,7 @@ describe("log.ts", () => {
 	beforeEach(() => {
 		robot = mockDeep<BreakingBot>();
 		// @ts-expect-error
-		robot.config = { ...testConfig };
+		robot.config = { ...config };
 		// @ts-expect-error
 		robot.incidents[TEST_ROOM] = newIncidentMachine(createIncident());
 	});

--- a/lib/core/__tests__/priority.test.ts
+++ b/lib/core/__tests__/priority.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { testConfig } from "../../../config/test.js";
+import { config } from "../../../config/index.js";
 import { createIncident } from "../../../test/index.js";
 import {
 	isHighPriority,
@@ -10,7 +10,7 @@ import {
 	priorityName,
 } from "../priority.js";
 
-const { priorities: testPriorityCfg } = testConfig;
+const { priorities: testPriorityCfg } = config;
 
 describe("priority.ts", () => {
 	describe("priorityName", () => {


### PR DESCRIPTION
### What

Switches the tests that rely on config to import from the re-exported `config`.

### Why

More consistant. And helps with misc deploy concerns.
