### PR TITLE
Fix unescaped . listener regexes

### DIFF
--- a/lib/boundary/hubot/scripts/init-listeners.ts
+++ b/lib/boundary/hubot/scripts/init-listeners.ts
@@ -62,7 +62,11 @@
 //   WPVIP
 
 import { isAnyCore4Set } from "../../../core/metrics.js";
-import { blockerAddRegex, helpRegex } from "../../../core/regex.js";
+import {
+	blockerAddRegex,
+	commandsRegex,
+	helpRegex,
+} from "../../../core/regex.js";
 import { incidentOverview } from "../../../data/incident.js";
 import {
 	getLogAisDb,
@@ -351,7 +355,7 @@ export default async (robot: BreakingBot) => {
 	);
 
 	robot.hear(
-		/^.(mitigate|mitigated)$/,
+		/^\.(mitigate|mitigated)$/,
 		{ id: "incident.mitigate", requireActiveIncident: true },
 		({ envelope: { room }, message }) => {
 			incidentMitigate(robot, room, message.user.id, message.id);
@@ -359,7 +363,7 @@ export default async (robot: BreakingBot) => {
 	);
 
 	robot.hear(
-		/^.(mitigate|mitigated)\b\s(\S.*)?$/,
+		/^\.(mitigate|mitigated)\b\s(\S.*)?$/,
 		{ id: "incident.mitigated:set", requireUpdatableIncident: true },
 		({ envelope: { room }, match, message }) => {
 			incidentSetMitigated(robot, room, match[2], message.user.id, message.id);
@@ -367,7 +371,7 @@ export default async (robot: BreakingBot) => {
 	);
 
 	robot.hear(
-		/^.genesis\s+(\S.*)$/,
+		/^\.genesis\s+(\S.*)$/,
 		{ id: "incident.genesis:set", requireUpdatableIncident: true },
 		({ envelope: { room }, match, message }) => {
 			incidentSetGenesis(robot, room, match[1], message.user.id, message.id);
@@ -375,7 +379,7 @@ export default async (robot: BreakingBot) => {
 	);
 
 	robot.hear(
-		/^.detected\s+(\S.*)$/,
+		/^\.detected\s+(\S.*)$/,
 		{ id: "incident.detected:set", requireUpdatableIncident: true },
 		({ envelope: { room }, match, message }) => {
 			incidentSetDetected(robot, room, match[1], message.user.id, message.id);
@@ -400,7 +404,7 @@ export default async (robot: BreakingBot) => {
 	);
 
 	robot.hear(
-		/^.(breakings|breakingchannels)/i,
+		/^\.(breakings|breakingchannels)/i,
 		{ id: "breakingchannels:get" },
 		({ envelope: { room }, message }) => {
 			const incidents = [];
@@ -690,7 +694,7 @@ export default async (robot: BreakingBot) => {
 	});
 
 	robot.hear(
-		/^.commands(?:\s+(.*))?$/i,
+		commandsRegex(),
 		{ id: "bot.commands" },
 		({ envelope: { room }, message }) => {
 			const commands = getHelpCommands(robot);

--- a/lib/boundary/hubot/scripts/init-listeners.ts
+++ b/lib/boundary/hubot/scripts/init-listeners.ts
@@ -62,7 +62,7 @@
 //   WPVIP
 
 import { isAnyCore4Set } from "../../../core/metrics.js";
-import { blockerAddRegex } from "../../../core/regex.js";
+import { blockerAddRegex, helpRegex } from "../../../core/regex.js";
 import { incidentOverview } from "../../../data/incident.js";
 import {
 	getLogAisDb,
@@ -685,7 +685,7 @@ export default async (robot: BreakingBot) => {
 		},
 	);
 
-	robot.hear(/^.help$/i, { id: "bot.help" }, ({ envelope, message }) => {
+	robot.hear(helpRegex(), { id: "bot.help" }, ({ envelope, message }) => {
 		robot.adapter.sendHelpMessage(envelope.room, robot.config, message.id);
 	});
 

--- a/lib/core/__tests__/regex.test.ts
+++ b/lib/core/__tests__/regex.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { blockerAddRegex, helpRegex } from "../regex.js";
+import { blockerAddRegex, commandsRegex, helpRegex } from "../regex.js";
 
 describe("regex.ts", () => {
 	describe("blockerAddRegex", () => {
@@ -69,6 +69,39 @@ describe("regex.ts", () => {
 		});
 	});
 
+	describe("commandsRegex", () => {
+		test('match ".commands" case insensitively', () => {
+			const regex = commandsRegex();
+			const commandLowercase = ".commands";
+			const commandUppercase = ".COMMANDS";
+			const commandMixedCase = ".CoMmaNds";
+
+			expect(regex.test(commandLowercase)).toBe(true);
+			expect(regex.test(commandUppercase)).toBe(true);
+			expect(regex.test(commandMixedCase)).toBe(true);
+		});
+
+		test('should not match strings that do not strictly match ".commands"', () => {
+			const regex = helpRegex();
+			const wrongCommands = [
+				".command",
+				"command",
+				".commandss",
+				"",
+				". commands",
+				" .commands",
+				"some.commands",
+				".commands ",
+				"bcommands",
+				".commands attention",
+			];
+
+			for (const command of wrongCommands) {
+				expect(regex.test(command)).toBe(false);
+			}
+		});
+	});
+
 	describe("helpRegex", () => {
 		test('match ".help" case insensitively', () => {
 			const regex = helpRegex();
@@ -92,7 +125,7 @@ describe("regex.ts", () => {
 				" .help",
 				"some.help",
 				".help ",
-				".Whelp",
+				"Whelp",
 				".help meeee",
 			];
 

--- a/lib/core/__tests__/regex.test.ts
+++ b/lib/core/__tests__/regex.test.ts
@@ -1,69 +1,104 @@
 import { describe, expect, test } from "vitest";
-import { blockerAddRegex } from "../regex.js";
+import { blockerAddRegex, helpRegex } from "../regex.js";
 
-describe("blockerAddRegex", () => {
-	test("match a simple blocked command with text", () => {
-		const str = ".blocked I don't want to get dressed";
-		const result = str.match(blockerAddRegex());
-		expect(result?.[1]).toBe("I don't want to get dressed");
+describe("regex.ts", () => {
+	describe("blockerAddRegex", () => {
+		test("match a simple blocked command with text", () => {
+			const str = ".blocked I don't want to get dressed";
+			const result = str.match(blockerAddRegex());
+			expect(result?.[1]).toBe("I don't want to get dressed");
+		});
+
+		test("match a blocker command with text", () => {
+			const result = ".blocker the park looks nice".match(blockerAddRegex());
+			expect(result?.[1]).toBe("the park looks nice");
+		});
+
+		test("match a blocker command with text and a result", () => {
+			const str =
+				".blocker i don't want to get dressed => it's soooooo much work";
+			const result = str.match(blockerAddRegex());
+			expect(result?.[1]).toBe("i don't want to get dressed");
+			expect(result?.[2]).toBe("it's soooooo much work");
+		});
+
+		test("match a blocked command with text and a result", () => {
+			const str =
+				".blocked i don't want to get dressed => it's soooooo much work";
+			const result = str.match(blockerAddRegex());
+			expect(result?.[1]).toBe("i don't want to get dressed");
+			expect(result?.[2]).toBe("it's soooooo much work");
+		});
+
+		test("match with trailing spaces", () => {
+			const str =
+				".blocked    something with spaces   =>   result with spaces   ";
+			const result = str.match(blockerAddRegex());
+			expect(result?.[1]).toBe("something with spaces");
+			expect(result?.[2]).toBe("result with spaces   ");
+		});
+
+		test("not match if not starting with .blocked or .blocker", () => {
+			const result1 = "blah .blocked action => result".match(blockerAddRegex());
+			const result2 = "some.blocker action".match(blockerAddRegex());
+			expect(result1).toBeNull();
+			expect(result2).toBeNull();
+		});
+
+		test("not match if => is immediately after the command", () => {
+			const result = ".blocked=>this is not valid".match(blockerAddRegex());
+			expect(result).toBeNull();
+		});
+
+		test("not match if there is no text after the command", () => {
+			const result = ".blocked".match(blockerAddRegex());
+			expect(result).toBeNull();
+		});
+
+		test("match regardless of case", () => {
+			const result = ".BLOCKED text goes here".match(blockerAddRegex());
+			expect(result?.[1]).toBe("text goes here");
+		});
+
+		test("match if there is an equal sign before the arrow", () => {
+			const result = ".blocked there=should => be a match".match(
+				blockerAddRegex(),
+			);
+			expect(result?.[1]).toBe("there=should");
+			expect(result?.[2]).toBe("be a match");
+		});
 	});
 
-	test("match a blocker command with text", () => {
-		const result = ".blocker the park looks nice".match(blockerAddRegex());
-		expect(result?.[1]).toBe("the park looks nice");
-	});
+	describe("helpRegex", () => {
+		test('match ".help" case insensitively', () => {
+			const regex = helpRegex();
+			const commandLowercase = ".help";
+			const commandUppercase = ".HELP";
+			const commandMixedCase = ".HeLp";
 
-	test("match a blocker command with text and a result", () => {
-		const str =
-			".blocker i don't want to get dressed => it's soooooo much work";
-		const result = str.match(blockerAddRegex());
-		expect(result?.[1]).toBe("i don't want to get dressed");
-		expect(result?.[2]).toBe("it's soooooo much work");
-	});
+			expect(regex.test(commandLowercase)).toBe(true);
+			expect(regex.test(commandUppercase)).toBe(true);
+			expect(regex.test(commandMixedCase)).toBe(true);
+		});
 
-	test("match a blocked command with text and a result", () => {
-		const str =
-			".blocked i don't want to get dressed => it's soooooo much work";
-		const result = str.match(blockerAddRegex());
-		expect(result?.[1]).toBe("i don't want to get dressed");
-		expect(result?.[2]).toBe("it's soooooo much work");
-	});
+		test('should not match strings that do not strictly match ".help"', () => {
+			const regex = helpRegex();
+			const wrongCommands = [
+				".helpp",
+				"help",
+				".h3lp",
+				"",
+				". help",
+				" .help",
+				"some.help",
+				".help ",
+				".Whelp",
+				".help meeee",
+			];
 
-	test("match with trailing spaces", () => {
-		const str =
-			".blocked    something with spaces   =>   result with spaces   ";
-		const result = str.match(blockerAddRegex());
-		expect(result?.[1]).toBe("something with spaces");
-		expect(result?.[2]).toBe("result with spaces   ");
-	});
-
-	test("not match if not starting with .blocked or .blocker", () => {
-		const result1 = "blah .blocked action => result".match(blockerAddRegex());
-		const result2 = "some.blocker action".match(blockerAddRegex());
-		expect(result1).toBeNull();
-		expect(result2).toBeNull();
-	});
-
-	test("not match if => is immediately after the command", () => {
-		const result = ".blocked=>this is not valid".match(blockerAddRegex());
-		expect(result).toBeNull();
-	});
-
-	test("not match if there is no text after the command", () => {
-		const result = ".blocked".match(blockerAddRegex());
-		expect(result).toBeNull();
-	});
-
-	test("match regardless of case", () => {
-		const result = ".BLOCKED text goes here".match(blockerAddRegex());
-		expect(result?.[1]).toBe("text goes here");
-	});
-
-	test("match if there is an equal sign before the arrow", () => {
-		const result = ".blocked there=should => be a match".match(
-			blockerAddRegex(),
-		);
-		expect(result?.[1]).toBe("there=should");
-		expect(result?.[2]).toBe("be a match");
+			for (const command of wrongCommands) {
+				expect(regex.test(command)).toBe(false);
+			}
+		});
 	});
 });

--- a/lib/core/__tests__/regex.test.ts
+++ b/lib/core/__tests__/regex.test.ts
@@ -82,7 +82,7 @@ describe("regex.ts", () => {
 		});
 
 		test('should not match strings that do not strictly match ".commands"', () => {
-			const regex = helpRegex();
+			const regex = commandsRegex();
 			const wrongCommands = [
 				".command",
 				"command",

--- a/lib/core/regex.ts
+++ b/lib/core/regex.ts
@@ -1,4 +1,6 @@
 export const blockerAddRegex = () =>
 	/^\.blocke(?:d|r)\s+([^=>]\S*.*?)(?:\s*=>\s*(\S.*))?$/i;
 
+export const commandsRegex = () => /^.commands(?:\s+(.*))?$/i;
+
 export const helpRegex = () => /^\.help$/i;

--- a/lib/core/regex.ts
+++ b/lib/core/regex.ts
@@ -1,6 +1,6 @@
 export const blockerAddRegex = () =>
 	/^\.blocke(?:d|r)\s+([^=>]\S*.*?)(?:\s*=>\s*(\S.*))?$/i;
 
-export const commandsRegex = () => /^.commands(?:\s+(.*))?$/i;
+export const commandsRegex = () => /^\.commands$/i;
 
 export const helpRegex = () => /^\.help$/i;

--- a/lib/core/regex.ts
+++ b/lib/core/regex.ts
@@ -1,2 +1,4 @@
 export const blockerAddRegex = () =>
 	/^\.blocke(?:d|r)\s+([^=>]\S*.*?)(?:\s*=>\s*(\S.*))?$/i;
+
+export const helpRegex = () => /^\.help$/i;


### PR DESCRIPTION
### What

Bad regexs, unescaped `.`, in `.help`, `.commands`, and other commands.

### Why

Brain no much.

### How

Fix two with some tests. Fix others with just a slash for now and circle back on expanding testing later.