### PR TITLE
Revert "Bump @slack/socket-mode from 1.3.4 to 2.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@slack/socket-mode": "2.0.0",
+				"@slack/socket-mode": "1.3.4",
 				"@slack/web-api": "7.0.4",
 				"drizzle-orm": "0.31.0",
 				"handlebars": "4.7.8",
@@ -946,33 +946,99 @@
 			"dev": true
 		},
 		"node_modules/@slack/logger": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
-			"integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+			"integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
 			"dependencies": {
-				"@types/node": ">=18.0.0"
+				"@types/node": ">=12.0.0"
 			},
 			"engines": {
-				"node": ">= 18",
-				"npm": ">= 8.6.0"
+				"node": ">= 12.13.0",
+				"npm": ">= 6.12.0"
 			}
 		},
 		"node_modules/@slack/socket-mode": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.0.tgz",
-			"integrity": "sha512-bcTAtJmLof2fu8LIcMVwUGD0XJ93x09tXCiYYUyEBkmmRbe8a1ze62aQkRWXmkM3bFFmNAVkPR55EGwFzQFu8g==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-1.3.4.tgz",
+			"integrity": "sha512-CBH5hrLgdSRUoEztKSgLk7wKLkZHXovFUNMTIRDBK6+w5tQNBFmiDL9Iovj3sJTu1lwRRdQKKzeMx/oyuoOf1A==",
 			"dependencies": {
-				"@slack/logger": "^4",
-				"@slack/web-api": "^7.0.1",
-				"@types/node": ">=18",
-				"@types/ws": "^8",
-				"eventemitter3": "^5",
+				"@slack/logger": "^3.0.0",
+				"@slack/web-api": "^6.11.2",
+				"@types/node": ">=12.0.0",
+				"@types/p-queue": "^2.3.2",
+				"@types/ws": "^7.4.7",
+				"eventemitter3": "^3.1.0",
 				"finity": "^0.5.4",
-				"ws": "^8"
+				"p-cancelable": "^1.1.0",
+				"p-queue": "^2.4.2",
+				"ws": "^7.5.3"
 			},
 			"engines": {
-				"node": ">= 18",
-				"npm": ">= 8.6.0"
+				"node": ">=12.13.0",
+				"npm": ">=6.12.0"
+			}
+		},
+		"node_modules/@slack/socket-mode/node_modules/@slack/web-api": {
+			"version": "6.11.2",
+			"resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.11.2.tgz",
+			"integrity": "sha512-s4qCQGXasr8jpCf/+6+V/smq+Z2RX7EIBnJeO/xe7Luie1nyBihFMgjICNyvzWoWBdaGntSnn5CcZdFm4ItBWg==",
+			"dependencies": {
+				"@slack/logger": "^3.0.0",
+				"@slack/types": "^2.11.0",
+				"@types/is-stream": "^1.1.0",
+				"@types/node": ">=12.0.0",
+				"axios": "^1.6.5",
+				"eventemitter3": "^3.1.0",
+				"form-data": "^2.5.0",
+				"is-electron": "2.2.2",
+				"is-stream": "^1.1.0",
+				"p-queue": "^6.6.1",
+				"p-retry": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 12.13.0",
+				"npm": ">= 6.12.0"
+			}
+		},
+		"node_modules/@slack/socket-mode/node_modules/@slack/web-api/node_modules/p-queue": {
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+			"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+			"dependencies": {
+				"eventemitter3": "^4.0.4",
+				"p-timeout": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@slack/socket-mode/node_modules/@slack/web-api/node_modules/p-queue/node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+		},
+		"node_modules/@slack/socket-mode/node_modules/form-data": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 0.12"
+			}
+		},
+		"node_modules/@slack/socket-mode/node_modules/is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@slack/types": {
@@ -1007,6 +1073,23 @@
 				"npm": ">= 8.6.0"
 			}
 		},
+		"node_modules/@slack/web-api/node_modules/@slack/logger": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+			"integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+			"dependencies": {
+				"@types/node": ">=18.0.0"
+			},
+			"engines": {
+				"node": ">= 18",
+				"npm": ">= 8.6.0"
+			}
+		},
+		"node_modules/@slack/web-api/node_modules/eventemitter3": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+		},
 		"node_modules/@slack/web-api/node_modules/p-queue": {
 			"version": "6.6.2",
 			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
@@ -1033,6 +1116,14 @@
 			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
+		"node_modules/@types/is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/luxon": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
@@ -1046,6 +1137,11 @@
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
+		},
+		"node_modules/@types/p-queue": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
+			"integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
 		},
 		"node_modules/@types/pg": {
 			"version": "8.11.6",
@@ -1147,9 +1243,9 @@
 			"peer": true
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.10",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-			"integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+			"version": "7.4.7",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+			"integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -2109,9 +2205,9 @@
 			}
 		},
 		"node_modules/eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
 		},
 		"node_modules/events": {
 			"version": "3.3.0",
@@ -2778,6 +2874,29 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/jsdom/node_modules/ws": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+			"integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
@@ -3135,6 +3254,14 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/p-cancelable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -3156,6 +3283,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-queue": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+			"integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng==",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/p-retry": {
@@ -4896,15 +5031,15 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-			"integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=8.3.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
+				"utf-8-validate": "^5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -5395,25 +5530,81 @@
 			"dev": true
 		},
 		"@slack/logger": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
-			"integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+			"integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
 			"requires": {
-				"@types/node": ">=18.0.0"
+				"@types/node": ">=12.0.0"
 			}
 		},
 		"@slack/socket-mode": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.0.tgz",
-			"integrity": "sha512-bcTAtJmLof2fu8LIcMVwUGD0XJ93x09tXCiYYUyEBkmmRbe8a1ze62aQkRWXmkM3bFFmNAVkPR55EGwFzQFu8g==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-1.3.4.tgz",
+			"integrity": "sha512-CBH5hrLgdSRUoEztKSgLk7wKLkZHXovFUNMTIRDBK6+w5tQNBFmiDL9Iovj3sJTu1lwRRdQKKzeMx/oyuoOf1A==",
 			"requires": {
-				"@slack/logger": "^4",
-				"@slack/web-api": "^7.0.1",
-				"@types/node": ">=18",
-				"@types/ws": "^8",
-				"eventemitter3": "^5",
+				"@slack/logger": "^3.0.0",
+				"@slack/web-api": "^6.11.2",
+				"@types/node": ">=12.0.0",
+				"@types/p-queue": "^2.3.2",
+				"@types/ws": "^7.4.7",
+				"eventemitter3": "^3.1.0",
 				"finity": "^0.5.4",
-				"ws": "^8"
+				"p-cancelable": "^1.1.0",
+				"p-queue": "^2.4.2",
+				"ws": "^7.5.3"
+			},
+			"dependencies": {
+				"@slack/web-api": {
+					"version": "6.11.2",
+					"resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.11.2.tgz",
+					"integrity": "sha512-s4qCQGXasr8jpCf/+6+V/smq+Z2RX7EIBnJeO/xe7Luie1nyBihFMgjICNyvzWoWBdaGntSnn5CcZdFm4ItBWg==",
+					"requires": {
+						"@slack/logger": "^3.0.0",
+						"@slack/types": "^2.11.0",
+						"@types/is-stream": "^1.1.0",
+						"@types/node": ">=12.0.0",
+						"axios": "^1.6.5",
+						"eventemitter3": "^3.1.0",
+						"form-data": "^2.5.0",
+						"is-electron": "2.2.2",
+						"is-stream": "^1.1.0",
+						"p-queue": "^6.6.1",
+						"p-retry": "^4.0.0"
+					},
+					"dependencies": {
+						"p-queue": {
+							"version": "6.6.2",
+							"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+							"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+							"requires": {
+								"eventemitter3": "^4.0.4",
+								"p-timeout": "^3.2.0"
+							},
+							"dependencies": {
+								"eventemitter3": {
+									"version": "4.0.7",
+									"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+									"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+								}
+							}
+						}
+					}
+				},
+				"form-data": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+					"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+				}
 			}
 		},
 		"@slack/types": {
@@ -5440,6 +5631,19 @@
 				"retry": "^0.13.1"
 			},
 			"dependencies": {
+				"@slack/logger": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+					"integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+					"requires": {
+						"@types/node": ">=18.0.0"
+					}
+				},
+				"eventemitter3": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+					"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+				},
 				"p-queue": {
 					"version": "6.6.2",
 					"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
@@ -5464,6 +5668,14 @@
 			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
+		"@types/is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/luxon": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
@@ -5477,6 +5689,11 @@
 			"requires": {
 				"undici-types": "~5.26.4"
 			}
+		},
+		"@types/p-queue": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
+			"integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
 		},
 		"@types/pg": {
 			"version": "8.11.6",
@@ -5565,9 +5782,9 @@
 			"peer": true
 		},
 		"@types/ws": {
-			"version": "8.5.10",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-			"integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+			"version": "7.4.7",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+			"integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -6223,9 +6440,9 @@
 			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
 		},
 		"eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
 		},
 		"events": {
 			"version": "3.3.0",
@@ -6711,6 +6928,15 @@
 						"tr46": "^5.0.0",
 						"webidl-conversions": "^7.0.0"
 					}
+				},
+				"ws": {
+					"version": "8.16.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+					"integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+					"dev": true,
+					"optional": true,
+					"peer": true,
+					"requires": {}
 				}
 			}
 		},
@@ -6986,6 +7212,11 @@
 				"ee-first": "1.1.1"
 			}
 		},
+		"p-cancelable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -6999,6 +7230,11 @@
 			"requires": {
 				"yocto-queue": "^1.0.0"
 			}
+		},
+		"p-queue": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+			"integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
 		},
 		"p-retry": {
 			"version": "4.6.2",
@@ -8231,9 +8467,9 @@
 			}
 		},
 		"ws": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-			"integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
 			"requires": {}
 		},
 		"xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@slack/socket-mode": "2.0.0",
+		"@slack/socket-mode": "1.3.4",
 		"@slack/web-api": "7.0.4",
 		"drizzle-orm": "0.31.0",
 		"handlebars": "4.7.8",


### PR DESCRIPTION
Reverts Automattic/breakingbot#39

Not quite as painless as they profess. :| 

Even Slack's BoltJS isn't using 2.x yet...