### PR TITLE
bump docker node image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   app:
     container_name: breaking_app
-    image: node:20
+    image: node:22
     environment:
       NODE_ENV: development
       DATABASE_URL: 'postgres://root:hunter2@breaking_db/breakingbot'


### PR DESCRIPTION
Bumping docker node image to node 22

### What

Currently, the package.json is specifying node 22.x here: https://github.com/Automattic/breakingbot/blob/ad138fb5b9e0719d2dbe9309d65b3399aacbcc07/package.json#L18

### Why

An error warning because the engine and the docker image are different versions

```
breaking_app  | npm warn EBADENGINE Unsupported engine {
breaking_app  | npm warn EBADENGINE   package: 'breakingbot@3.1.0',
breaking_app  | npm warn EBADENGINE   required: { node: '22.x' },
breaking_app  | npm warn EBADENGINE   current: { node: 'v20.14.0', npm: '10.7.0' }
breaking_app  | npm warn EBADENGINE }
``` 

### How

Just brings node docker image inline with the engine specified in `package.json`