### PR TITLE
Fix SIGTERM error on postgres exit

### DIFF
--- a/lib/boundary/hubot/scripts/init-00-postgres.ts
+++ b/lib/boundary/hubot/scripts/init-00-postgres.ts
@@ -50,11 +50,13 @@ export default async (robot: BreakingBot) => {
 			await client.end();
 			robot.logger.info("Shutdown complete.");
 			process.exit(0);
-		} catch (err: any) {
-			robot.logger.error(
-				`Error during shutdown: ${JSON.stringify(err.message)}`,
-				`Error stack: ${JSON.stringify(err.stack)}`,
-			);
+		} catch (err: unknown) {
+			if (err instanceof Error) {
+				robot.logger.error(
+					`Error during shutdown: ${JSON.stringify(err.message)}`,
+					`Error stack: ${JSON.stringify(err.stack)}`,
+				);
+			}
 
 			process.exit(1);
 		}

--- a/lib/boundary/hubot/scripts/init-00-postgres.ts
+++ b/lib/boundary/hubot/scripts/init-00-postgres.ts
@@ -38,27 +38,27 @@ export default async (robot: BreakingBot) => {
 
 	robot.db = drizzle(client, { schema });
 
-const handleExit = async (signal: string) => {
-	robot.logger.info(`Received ${signal}. Shutting down.`);
-	robot.logger.info(`Process ID: ${process.pid}`);
+	const handleExit = async (signal: string) => {
+		robot.logger.info(`Received ${signal}. Shutting down.`);
+		robot.logger.info(`Process ID: ${process.pid}`);
 
-	try {
-		stopAnnoyotron(robot.annoyotron); 
-		stopArchivist(robot.archivist);
-		stopSyntrax(robot.syntrax);
-		robot.shutdown();
-		await client.end();
-		robot.logger.info("Shutdown complete.");
-		process.exit(0);
-	} catch (err: any) {
-		robot.logger.error(
-			`Error during shutdown: ${JSON.stringify(err.message)}`,
-			`Error stack: ${JSON.stringify(err.stack)}`,
-		);
+		try {
+			stopAnnoyotron(robot.annoyotron);
+			stopArchivist(robot.archivist);
+			stopSyntrax(robot.syntrax);
+			robot.shutdown();
+			await client.end();
+			robot.logger.info("Shutdown complete.");
+			process.exit(0);
+		} catch (err: any) {
+			robot.logger.error(
+				`Error during shutdown: ${JSON.stringify(err.message)}`,
+				`Error stack: ${JSON.stringify(err.stack)}`,
+			);
 
-		process.exit(1);
-	}
-};
+			process.exit(1);
+		}
+	};
 
 	process.on("SIGINT", handleExit);
 	process.on("SIGTERM", handleExit);

--- a/lib/boundary/hubot/scripts/init-00-postgres.ts
+++ b/lib/boundary/hubot/scripts/init-00-postgres.ts
@@ -38,16 +38,27 @@ export default async (robot: BreakingBot) => {
 
 	robot.db = drizzle(client, { schema });
 
-	const handleExit = async (signal: string) => {
-		robot.logger.info(`Received ${signal}. Shutting down.`);
-		stopAnnoyotron(robot.annoyotron);
+const handleExit = async (signal: string) => {
+	robot.logger.info(`Received ${signal}. Shutting down.`);
+	robot.logger.info(`Process ID: ${process.pid}`);
+
+	try {
+		stopAnnoyotron(robot.annoyotron); 
 		stopArchivist(robot.archivist);
 		stopSyntrax(robot.syntrax);
 		robot.shutdown();
 		await client.end();
 		robot.logger.info("Shutdown complete.");
-		process.exitCode = 0;
-	};
+		process.exit(0);
+	} catch (err: any) {
+		robot.logger.error(
+			`Error during shutdown: ${JSON.stringify(err.message)}`,
+			`Error stack: ${JSON.stringify(err.stack)}`,
+		);
+
+		process.exit(1);
+	}
+};
 
 	process.on("SIGINT", handleExit);
 	process.on("SIGTERM", handleExit);


### PR DESCRIPTION
### What

When `ts-watch` is running `process.exitCode = 0` would result in a `SIGTERM`. Switching to `process.exit(0)` resolves the issue.

### Why

Bug fix and some additional logging added just in case.

### How

While developing locally, code changes will reload the app using `ts-watch` without failing and exiting due to ``SIGTERM`