### PR TITLE
Add typechecking to test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"postinstall": "git rev-parse --is-inside-work-tree > /dev/null 2>&1 && git config core.hooksPath .githooks || exit 0",
 		"start": "bin/hubot -f ./dist/lib/boundary/hubot/adapters/slack.js",
 		"start:dev": "APP_ENV=dev tsc-watch --onSuccess 'bin/hubot -f ./dist/lib/boundary/hubot/adapters/slack.js'",
-		"test": "APP_ENV=test TZ=UTC vitest --watch=false",
+		"test": "APP_ENV=test TZ=UTC vitest --watch=false && tsc --noEmit",
 		"test:watch": "APP_ENV=test TZ=UTC vitest"
 	},
 	"engines": {


### PR DESCRIPTION
### What

Adds `tsc --noEmit` so that `npm test` does type checking.

### Why

At the moment, CI doesn't actually invoke any type checking which can let things hit deploy build step(s) in unexpected ways at times.
