### PR TITLE
Priority upgrade notifications

### DIFF
--- a/lib/boundary/comm-platform.ts
+++ b/lib/boundary/comm-platform.ts
@@ -19,6 +19,11 @@ export interface CommPlatform {
 		mainRoom: string,
 		notifyRoom?: string,
 	): Promise<unknown>;
+	notifyIncidentPriorityUpgrade(
+		incident: Incident,
+		mainRoom: string,
+		notifyRoom?: string,
+	): Promise<unknown>;
 	notifyNewLowIncident(incident: Incident, mainRoom: string): Promise<unknown>;
 	introNewIncident(
 		incident: Incident,

--- a/lib/boundary/hubot/adapters/__tests__/slack.test.ts
+++ b/lib/boundary/hubot/adapters/__tests__/slack.test.ts
@@ -14,6 +14,7 @@ import {
 	mrkdownBlock,
 	newBreakingBlocks,
 	priorityBlocks,
+	upgradePriorityBlocks,
 } from "../slack/blocks.js";
 import { allClear, fiery, incidentCanceled } from "../slack/emoji.js";
 
@@ -115,6 +116,34 @@ describe("slack.ts", () => {
 					),
 					channel: "C3984354",
 					text: ":fire: <#unit-test-breaking-42>: *TESTING 123* started by <@hanni>",
+				}),
+			);
+		});
+
+		test("fails fast if no chatRoomUid", () => {
+			const incident = createIncident({ chatRoomUid: null });
+			expectProcessExit(async () =>
+				slack.notifyNewIncident(incident, "C3984354"),
+			);
+		});
+	});
+
+	describe("notifyIncidentPriorityUpgrade", () => {
+		test("success", async () => {
+			const incident = createIncident();
+
+			await slack.notifyIncidentPriorityUpgrade(incident, "C3984354");
+
+			expect(webClient.chat.postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					blocks: upgradePriorityBlocks(
+						incident.title,
+						2,
+						incident.chatRoomUid || "",
+						incident.createdBy,
+					),
+					channel: "C3984354",
+					text: "[P2]:fire: *Testing 123* upgraded by <@hanni> in <#unit-test-breaking-42>",
 				}),
 			);
 		});

--- a/lib/boundary/hubot/adapters/slack.ts
+++ b/lib/boundary/hubot/adapters/slack.ts
@@ -47,6 +47,7 @@ import {
 	statusBlocks,
 	summaryBlocks,
 	summaryBodyBlock,
+	upgradePriorityBlocks,
 } from "./slack/blocks.js";
 import {
 	affected as affectedEmoji,
@@ -163,6 +164,36 @@ export class Slack extends Adapter implements CommPlatform {
 		const fmtUser = this.fmtUser(createdBy);
 		const text = `:${emoji}: ${fmtRoom}: *${title.toUpperCase()}* started by ${fmtUser}`;
 
+		const tasks = [this.#sendToChannel(mainChannel, blocks, text)];
+
+		if (notifyChannel) {
+			tasks.push(this.#sendToChannel(notifyChannel, blocks, text));
+		}
+
+		return Promise.allSettled(tasks);
+	}
+
+	notifyIncidentPriorityUpgrade(
+		{ title, chatRoomUid, createdBy, priority }: Incident,
+		mainChannel: string,
+		notifyChannel?: string,
+	) {
+		if (!chatRoomUid) {
+			return this.#failFast(
+				"notifyIncidentPriorityUpgrade: Missing chat room!",
+			);
+		}
+
+		const blocks = upgradePriorityBlocks(
+			title,
+			priority,
+			chatRoomUid,
+			createdBy,
+		);
+		const emoji = priorityEmoji(priority);
+		const fmtRoom = this.fmtRoom(chatRoomUid);
+		const fmtUser = this.fmtUser(createdBy);
+		const text = `[P${priority}]:${emoji}: *${title}* upgraded by ${fmtUser} in ${fmtRoom}`;
 		const tasks = [this.#sendToChannel(mainChannel, blocks, text)];
 
 		if (notifyChannel) {

--- a/lib/boundary/hubot/adapters/slack/__tests__/blocks.test.ts
+++ b/lib/boundary/hubot/adapters/slack/__tests__/blocks.test.ts
@@ -16,6 +16,7 @@ import {
 	notesBlocks,
 	priorityBlocks,
 	richTextBlock,
+	upgradePriorityBlocks,
 } from "../blocks.js";
 
 describe("slack/blocks.ts", () => {
@@ -207,6 +208,35 @@ describe("slack/blocks.ts", () => {
 		expect(result).toEqual(expectedOutput);
 	});
 
+	test("upgradePriorityBlocks", () => {
+		const expectedOutput = [
+			{
+				type: "header",
+				text: {
+					type: "plain_text",
+					text: "[P2] Breaking Incident Upgraded!",
+					emoji: true,
+				},
+			},
+			{
+				type: "section",
+				text: {
+					type: "mrkdwn",
+					text: ":fire: *Breaking News*: has been upgraded to *P2*!\n\nupgraded by <@U12345> in <#C12345> <!channel>",
+				},
+			},
+			{ type: "divider" },
+		];
+
+		const result = upgradePriorityBlocks(
+			"Breaking News",
+			2,
+			"C12345",
+			"U12345",
+		);
+		expect(result).toEqual(expectedOutput);
+	});
+
 	test("priorityBlocks", () => {
 		expect(priorityBlocks(config.priorities)).toStrictEqual([
 			{
@@ -224,7 +254,7 @@ describe("slack/blocks.ts", () => {
 			{
 				text: {
 					emoji: true,
-					text: ":fire: P2 [default]",
+					text: ":fire: P2",
 					type: "plain_text",
 				},
 				type: "header",
@@ -236,7 +266,7 @@ describe("slack/blocks.ts", () => {
 			{
 				text: {
 					emoji: true,
-					text: ":dash: P3",
+					text: ":dash: P3 [default]",
 					type: "plain_text",
 				},
 				type: "header",

--- a/lib/boundary/hubot/adapters/slack/__tests__/strings.test.ts
+++ b/lib/boundary/hubot/adapters/slack/__tests__/strings.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import { mockDeep } from "vitest-mock-extended";
-import { config } from "../../../../../../config/index.js";
 import {
 	createBlocker,
 	createIncident,
@@ -8,12 +7,7 @@ import {
 } from "../../../../../../test/index.js";
 import { priorityEmoji } from "../../../../../core/priority.js";
 import type { IssueTracker } from "../../../../issue-tracker.js";
-import {
-	blocked,
-	hiPriority,
-	incidentInactive,
-	lowPriority,
-} from "../emoji.js";
+import { blocked, hiPriority, incidentInactive } from "../emoji.js";
 import {
 	decodeHtmlEntities,
 	encodeHtmlEntities,
@@ -52,11 +46,12 @@ describe("slack/string.ts", () => {
 		test("active incident without roles and without blockage", () => {
 			const inactiveIncident = createIncident({
 				title: "Test Incident Low Priority",
-				priority: config.priorities.defaultLow,
+				priority: 5,
 			});
 
 			const topic = fmtIncidentTopic(inactiveIncident);
-			const expectedTopic = `:${lowPriority()}: [P3] *TEST INCIDENT LOW PRIORITY* - Point: _nobody_, Comms: _nobody_`;
+			const expectedTopic =
+				":heavy_multiplication_x: [P5] *TEST INCIDENT LOW PRIORITY* - Point: _nobody_, Comms: _nobody_";
 
 			expect(topic).toEqual(expectedTopic);
 		});

--- a/lib/boundary/hubot/adapters/slack/blocks.ts
+++ b/lib/boundary/hubot/adapters/slack/blocks.ts
@@ -191,6 +191,21 @@ export const newBreakingBlocks = (
 	];
 };
 
+export const upgradePriorityBlocks = (
+	title: string,
+	priority: number,
+	channel: string,
+	createdBy: string,
+) => {
+	return [
+		headerBlock(`[P${priority}] Breaking Incident Upgraded!`),
+		mrkdownBlock(
+			`:${hiPriority()}: *${title}*: has been upgraded to *P${priority}*!\n\nupgraded by <@${createdBy}> in <#${channel}> <!channel>`,
+		),
+		divider(),
+	];
+};
+
 export const newLowBreakingBlocks = (
 	title: string,
 	channel: string,

--- a/lib/boundary/hubot/handlers/incident.ts
+++ b/lib/boundary/hubot/handlers/incident.ts
@@ -1058,6 +1058,7 @@ export const incidentSetPriority = async (
 	createdBy: string,
 	messageId?: string,
 ) => {
+	const { config } = robot;
 	const incident = robot.incidents[room].data();
 
 	if (!isValidPriority(priority)) {
@@ -1078,6 +1079,7 @@ export const incidentSetPriority = async (
 		return robot.adapter.sendError(room, "Failed to set priority!", messageId);
 	}
 
+	const oldPriority: number = incident.priority;
 	incident.priority = priority;
 
 	const url = await permalink(robot.adapter, room, messageId);
@@ -1092,6 +1094,16 @@ export const incidentSetPriority = async (
 			url,
 		),
 	];
+
+	if (isHighPriority(priority) && oldPriority > priority) {
+		tasks.push(
+			robot.adapter.notifyIncidentPriorityUpgrade(
+				incident,
+				config.breakingMainRoom,
+				config.breakingNotifyRoom,
+			),
+		);
+	}
 
 	return Promise.allSettled(tasks);
 };

--- a/lib/core/__tests__/priority.test.ts
+++ b/lib/core/__tests__/priority.test.ts
@@ -54,12 +54,6 @@ describe("priority.ts", () => {
 		test("P4", () => {
 			expect(isHighPriority(4, testPriorityCfg)).toBe(false);
 		});
-
-		test("Everything high priority if no low configured", () => {
-			expect(
-				isHighPriority(4, { ...testPriorityCfg, defaultLow: undefined }),
-			).toBe(true);
-		});
 	});
 
 	describe("isReviewRequiredForPriority", () => {

--- a/lib/core/priority.ts
+++ b/lib/core/priority.ts
@@ -45,7 +45,14 @@ export const isHighPriority = (
 	priority: number,
 	cfg = config.priorities,
 ): boolean => {
-	return !cfg.defaultLow || priority < cfg.defaultLow;
+	const priorityConfig = cfg.priorities[priority];
+
+	// Check if isHighPriority exists and is set to true
+	if (priorityConfig && priorityConfig.isHighPriority === true) {
+		return true;
+	}
+
+	return false;
 };
 
 export const isReviewRequiredForPriority = (

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "breakingbot",
 	"description": "Breaking Bot",
-	"version": "3.1.0",
+	"version": "3.1.2",
 	"author": "WPVIP",
 	"license": "GPL-2.0-or-later",
 	"scripts": {


### PR DESCRIPTION
### What

Enables Slack notifications when an incident is upgraded to a high-priority incident.

### Why

Currently, if you start a low incident and then change the priority to a P1, notifications are not sent out to the specified Slack channel

### How

<!-- How does it work? Remarkable details, questions, edge cases, unfinished work, etc. -->

<!-- Screenshots, videos, GIFs, links, etc. -->